### PR TITLE
[WW-3824] Add form support to toggle input component

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -18,6 +18,9 @@ Renders a toggle switch for enabling/disabling options with click/tap interactio
 - selectorColorOn: string|null - On state selector color. Default: null. Mandatory
 - backgroundColorOff: string|null - Off state background color. Default: null. Mandatory
 - backgroundColorOn: string|null - On state background color. Default: null. Mandatory
+- fieldName: string - Form field name for identification. Default: ""
+- customValidation: boolean - Enable custom validation. Default: false
+- validation: Formula - Custom validation formula. Requires customValidation to be true!
 
 ***Exposed Variables:***
 - value: boolean - Current toggle state. (path: variables['current_element_uid-value'])

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 
 export default {
     props: {
@@ -40,13 +40,26 @@ export default {
         /* wwEditor:end */
     },
     emits: ['update:content:effect', 'trigger-event', 'add-state', 'remove-state'],
-    setup(props) {
+    setup(props, { emit }) {
         const { value: variableValue, setValue } = wwLib.wwVariable.useComponentVariable({
             uid: props.uid,
             name: 'value',
             type: 'boolean',
             defaultValue: computed(() => (props.content.value === undefined ? false : props.content.value)),
         });
+
+        const useForm = inject('_wwForm:useForm', () => {});
+
+        const fieldName = computed(() => props.content.fieldName);
+        const validation = computed(() => props.content.validation);
+        const customValidation = computed(() => props.content.customValidation);
+        const required = computed(() => props.content.required);
+
+        useForm(
+            variableValue,
+            { fieldName, validation, customValidation, required, initialValue: computed(() => props.content.value) },
+            { elementState: props.wwElementState, emit, sidepanelFormPath: 'form', setValue }
+        );
 
         return { variableValue, setValue };
     },

--- a/ww-config.js
+++ b/ww-config.js
@@ -5,6 +5,13 @@ export default {
             fr: 'Toggle',
         },
         icon: 'toggle',
+        customSettingsPropertiesOrder: [
+            'formInfobox',
+            ['fieldName', 'customValidation', 'validation'],
+            'value',
+            'readonly',
+            'required',
+        ],
     },
     options: {
         ignoredStyleProperties: ['background'],
@@ -128,6 +135,54 @@ export default {
                 action: 'toggleValue',
             },
             editorOnly: true,
+        },
+        /* wwEditor:start */
+        form: {
+            editorOnly: true,
+            hidden: true,
+            defaultValue: false,
+        },
+        formInfobox: {
+            type: 'InfoBox',
+            section: 'settings',
+            options: (_, sidePanelContent) => ({
+                variant: sidePanelContent.form?.name ? 'success' : 'warning',
+                icon: 'pencil',
+                title: sidePanelContent.form?.name || 'Unnamed form',
+                content: !sidePanelContent.form?.name && 'Give your form a meaningful name.',
+            }),
+            hidden: (_, sidePanelContent) => !sidePanelContent.form?.uid,
+        },
+        /* wwEditor:end */
+        fieldName: {
+            label: 'Field name',
+            section: 'settings',
+            type: 'Text',
+            defaultValue: '',
+            bindable: true,
+            hidden: (_, sidePanelContent) => {
+                return !sidePanelContent.form?.uid;
+            },
+        },
+        customValidation: {
+            label: 'Custom validation',
+            section: 'settings',
+            type: 'OnOff',
+            defaultValue: false,
+            bindable: true,
+            hidden: (_, sidePanelContent) => {
+                return !sidePanelContent.form?.uid;
+            },
+        },
+        validation: {
+            label: 'Validation',
+            section: 'settings',
+            type: 'Formula',
+            defaultValue: '',
+            bindable: true,
+            hidden: (content, sidePanelContent) => {
+                return !sidePanelContent.form?.uid || !content.customValidation;
+            },
         },
     },
 };


### PR DESCRIPTION
## Summary
- Added form support to the ww-input-toggle component by implementing 5 form properties and useForm composable integration
- Enhanced editor UX with form info box and better property ordering